### PR TITLE
Fix GPU/CPU allocation

### DIFF
--- a/desc/__init__.py
+++ b/desc/__init__.py
@@ -42,6 +42,7 @@ def set_device(kind="cpu"):
     """
     if kind == "cpu":
         os.environ["JAX_PLATFORM_NAME"] = "cpu"
+        os.environ["CUDA_VISIBLE_DEVICES"] = ""
         import psutil
 
         cpu_mem = psutil.virtual_memory().available / 1024 ** 3  # RAM in GB


### PR DESCRIPTION
JAX was still grabbing the whole gpu even if you told it to use CPU, this should fix it by hiding all gpus from jax